### PR TITLE
fix connection timeout block interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.github.aznamier.keycloak.event.provider</groupId>
     <artifactId>keycloak-to-rabbit</artifactId>
     <packaging>jar</packaging>
-	<version>3.0.2</version>
+	<version>3.0.3</version>
     
 
 

--- a/src/main/java/com/github/aznamier/keycloak/event/provider/RabbitMqConfig.java
+++ b/src/main/java/com/github/aznamier/keycloak/event/provider/RabbitMqConfig.java
@@ -1,17 +1,16 @@
 package com.github.aznamier.keycloak.event.provider;
 
+import com.rabbitmq.client.ConnectionFactory;
 
 import java.util.Locale;
 import java.util.regex.Pattern;
+
 import org.jboss.logging.Logger;
+
 import org.keycloak.Config.Scope;
 import org.keycloak.events.Event;
 import org.keycloak.events.admin.AdminEvent;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.keycloak.util.JsonSerialization;
-
 
 public class RabbitMqConfig {
 
@@ -116,49 +115,32 @@ public class RabbitMqConfig {
 		return value;
 		
 	}
-	
-	
-	public String getHostUrl() {
-		return hostUrl;
-	}
-	public void setHostUrl(String hostUrl) {
-		this.hostUrl = hostUrl;
-	}
-	public Integer getPort() {
-		return port;
-	}
-	public void setPort(Integer port) {
-		this.port = port;
-	}
-	public String getUsername() {
-		return username;
-	}
-	public void setUsername(String username) {
-		this.username = username;
-	}
-	public String getPassword() {
-		return password;
-	}
-	public void setPassword(String password) {
-		this.password = password;
-	}
-	public String getVhost() {
-		return vhost;
-	}
-	public void setVhost(String vhost) {
-		this.vhost = vhost;
-	}
-	public Boolean getUseTls() {
-		return useTls;
-	}
-	public void setUseTls(Boolean useTls) {
-		this.useTls = useTls;
-	}
+
 	public String getExchange() {
 		return exchange;
 	}
 	public void setExchange(String exchange) {
 		this.exchange = exchange;
+	}
+
+	public ConnectionFactory newConnectionFactory() {
+		ConnectionFactory cf = new ConnectionFactory();
+		cf.setUsername(username);
+        cf.setPassword(password);
+        cf.setVirtualHost(vhost);
+        cf.setHost(hostUrl);
+        cf.setPort(port);
+        cf.setAutomaticRecoveryEnabled(true);
+
+        if (useTls.booleanValue()) {
+            try {
+                cf.useSslProtocol();
+            }
+            catch (Exception e) {
+                log.error("Could not use SSL protocol", e);
+            }
+        }
+        return cf;
 	}
 
 }

--- a/src/main/java/com/github/aznamier/keycloak/event/provider/RabbitMqEventListenerProviderFactory.java
+++ b/src/main/java/com/github/aznamier/keycloak/event/provider/RabbitMqEventListenerProviderFactory.java
@@ -1,11 +1,5 @@
 package com.github.aznamier.keycloak.event.provider;
 
-import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.ConnectionFactory;
-import java.io.IOException;
-import java.util.concurrent.TimeoutException;
-import org.jboss.logging.Logger;
 import org.keycloak.Config.Scope;
 import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.EventListenerProviderFactory;
@@ -14,52 +8,16 @@ import org.keycloak.models.KeycloakSessionFactory;
 
 public class RabbitMqEventListenerProviderFactory implements EventListenerProviderFactory {
 
-    private static final Logger log = Logger.getLogger(RabbitMqEventListenerProviderFactory.class);
     private RabbitMqConfig cfg;
-    private ConnectionFactory connectionFactory;
-    private Connection connection;
-    private Channel channel;
 
     @Override
     public EventListenerProvider create(KeycloakSession session) {
-        checkConnectionAndChannel();
-        return new RabbitMqEventListenerProvider(channel, session, cfg);
-    }
-
-    private synchronized void checkConnectionAndChannel() {
-        try {
-            if (connection == null || !connection.isOpen()) {
-                this.connection = connectionFactory.newConnection();
-            }
-            if (channel == null || !channel.isOpen()) {
-                channel = connection.createChannel();
-            }
-        }
-        catch (IOException | TimeoutException e) {
-            log.error("keycloak-to-rabbitmq ERROR on connection to rabbitmq", e);
-        }
+        return new RabbitMqEventListenerProvider(session, cfg);
     }
 
     @Override
     public void init(Scope config) {
         cfg = RabbitMqConfig.createFromScope(config);
-        this.connectionFactory = new ConnectionFactory();
-
-        this.connectionFactory.setUsername(cfg.getUsername());
-        this.connectionFactory.setPassword(cfg.getPassword());
-        this.connectionFactory.setVirtualHost(cfg.getVhost());
-        this.connectionFactory.setHost(cfg.getHostUrl());
-        this.connectionFactory.setPort(cfg.getPort());
-        this.connectionFactory.setAutomaticRecoveryEnabled(true);
-
-        if (cfg.getUseTls()) {
-            try {
-                this.connectionFactory.useSslProtocol();
-            }
-            catch (Exception e) {
-                log.error("Could not use SSL protocol", e);
-            }
-        }
     }
 
     @Override
@@ -69,13 +27,7 @@ public class RabbitMqEventListenerProviderFactory implements EventListenerProvid
 
     @Override
     public void close() {
-        try {
-            channel.close();
-            connection.close();
-        }
-        catch (IOException | TimeoutException e) {
-            log.error("keycloak-to-rabbitmq ERROR on close", e);
-        }
+
     }
 
     @Override


### PR DESCRIPTION
RabbitMqEventListenerProviderFactory is called for each click on interface. Creating a connection in this factory is useless. It seems to be in the same thread as the interface and can block user if rabbitmq is down.

#30 