### PR TITLE
TLS connection with Peer Verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 .project
 .classpath
 .idea
+.vscode/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ therefore its easy for Rabbit client to subscribe to selective combinations eg:
   - `KK_TO_RMQ_USERNAME` - default: *guest*
   - `KK_TO_RMQ_PASSWORD` - default: *guest*
   - `KK_TO_RMQ_USE_TLS` - default: *false*
+  - `KK_TO_RMQ_KEY_STORE` - default: *empty*
+  - `KK_TO_RMQ_KEY_STORE_PASS` - default: *empty*
+  - `KK_TO_RMQ_TRUST_STORE` - default: *empty*
+  - `KK_TO_RMQ_TRUST_STORE_PASS` - default: *empty*
 
 ###### Deprecated OPTION 2: edit Keycloak subsystem of WildFly (Keycloak 16 and older) standalone.xml or standalone-ha.xml:
 
@@ -78,7 +82,10 @@ therefore its easy for Rabbit client to subscribe to selective combinations eg:
             <property name="vhost" value="${env.KK_TO_RMQ_VHOST:}"/>
             <property name="exchange" value="${env.KK_TO_RMQ_EXCHANGE:amq.topic}"/>
             <property name="use_tls" value="${env.KK_TO_RMQ_USE_TLS:false}"/>
-            
+            <property name="key_store" value="${env.KK_TO_RMQ_KEY_STORE:}"/>
+            <property name="key_store_pass" value="${env.KK_TO_RMQ_KEY_STORE_PASS:}"/> 
+            <property name="trust_store" value="${env.KK_TO_RMQ_TRUST_STORE:}"/>
+            <property name="trust_store_pass" value="${env.KK_TO_RMQ_TRUST_STORE_PASS:}"/>           
             <property name="username" value="${env.KK_TO_RMQ_USERNAME:guest}"/>
             <property name="password" value="${env.KK_TO_RMQ_PASSWORD:guest}"/>
         </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.github.aznamier.keycloak.event.provider</groupId>
     <artifactId>keycloak-to-rabbit</artifactId>
     <packaging>jar</packaging>
-	<version>3.0.2</version>
+	<version>3.0.3</version>
     
 
 

--- a/src/main/java/com/github/aznamier/keycloak/event/provider/RabbitMqConfig.java
+++ b/src/main/java/com/github/aznamier/keycloak/event/provider/RabbitMqConfig.java
@@ -28,6 +28,14 @@ public class RabbitMqConfig {
 	private String vhost;
 	private Boolean useTls;
 
+	// SSL context settings
+	private String trustStore;
+	private String trustStorePass;
+	private String keyStore;
+	private String keyStorePass;
+	//
+
+
 	private String exchange;
 	
 	public static String calculateRoutingKey(AdminEvent adminEvent) {
@@ -92,6 +100,13 @@ public class RabbitMqConfig {
 		cfg.vhost = resolveConfigVar(config, "vhost", "");
 		cfg.useTls = Boolean.valueOf(resolveConfigVar(config, "use_tls", "false"));
 
+		// SSL context settings
+		cfg.trustStore = resolveConfigVar(config, "trust_store", "");
+		cfg.trustStorePass = resolveConfigVar(config, "trust_store_pass", "");
+		cfg.keyStore = resolveConfigVar(config, "key_store", "");
+		cfg.keyStorePass = resolveConfigVar(config, "key_store_pass", "");
+		//
+
 		cfg.exchange = resolveConfigVar(config, "exchange", "amq.topic");
 		return cfg;
 		
@@ -154,6 +169,34 @@ public class RabbitMqConfig {
 	public void setUseTls(Boolean useTls) {
 		this.useTls = useTls;
 	}
+
+	// setters and getters SSL context setting
+	public void setTrustStore(String trustStore) {
+		this.trustStore = trustStore;
+	}
+	public void setTrustStorePass(String trustStorePass) {
+		this.trustStorePass = trustStorePass;
+	}
+	public void setKeyStore(String keyStore) {
+		this.keyStore = keyStore;
+	}
+	public void setKeyStorePass(String keyStorePass) {
+		this.keyStorePass = keyStorePass;
+	}
+	public String getTrustStore() {
+		return trustStore;
+	}
+	public String getTrustStorePass() {
+		return trustStorePass;
+	}
+	public String getKeyStore() {
+		return keyStore;
+	}
+	public String getKeytStorePass() {
+		return keyStorePass;
+	}
+	//
+
 	public String getExchange() {
 		return exchange;
 	}


### PR DESCRIPTION
#32 
Adding support for TLS connection with Peer Verification.
Configuration parameters added:
- KK_TO_RMQ_KEY_STORE - default: empty
- KK_TO_RMQ_KEY_STORE_PASS - default: empty
- KK_TO_RMQ_TRUST_STORE - default: empty
- KK_TO_RMQ_TRUST_STORE_PASS - default: empty